### PR TITLE
Switch MongoDB to use dynamic EBS volumes via CSI Driver

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -52,7 +52,7 @@ jobs:
             file: ./scripts/Dockerfile.migration
             push: true
             tags: |
-              ${{ env.DOCKER_USERNAME }}/easyshop-migration:${{ github.sha}}
+              ${{ env.DOCKER_USERNAME }}/easyshop-migration:${{ github.sha }}
             labels: |
               org.opencontainers.image.source=${{ github.repository }}
               org.opencontainers.image.revision=${{ github.sha }}
@@ -79,7 +79,7 @@ jobs:
             git config --local user.name "GitHub Action"
             
         - name: Pull latest changes from the remote branch
-          run: git pull origin master --rebase
+          run: git pull origin ${{ github.event.repository.default_branch }} --rebase
 
 
         - name: Update App image tag in manifest file
@@ -105,4 +105,4 @@ jobs:
           uses: ad-m/github-push-action@v0.6.0
           with: 
             github_token: ${{ secrets.GITHUB_TOKEN }}
-            branch: master
+            branch: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -1,0 +1,108 @@
+name: tws-e-commerce-app Pipeline
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: write 
+
+jobs: 
+    continuous_integration:
+      runs-on: ubuntu-latest
+      env:
+          DOCKER_USERNAME: joakim077
+          
+      steps:
+        - name: Checkout Code
+          uses: actions/checkout@v4
+
+        - name: Unit testing
+          run: |
+            echo "Unit testing"
+
+        - name: Code Coverage
+          run: | 
+            echo "Code Coverage and upload artifact"
+
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v2
+  
+        - name: Log in to Docker Hub
+          uses: docker/login-action@v2
+          with:
+            username: ${{ env.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
+
+        - name: Build and push App image
+          uses: docker/build-push-action@v4
+          with:
+            push: true
+            tags: |
+              ${{ env.DOCKER_USERNAME }}/easyshop-app:${{ github.sha }}
+            labels: |
+              org.opencontainers.image.source=${{ github.repository }}
+              org.opencontainers.image.revision=${{ github.sha }}
+        
+        - name: Build and push Migration Image
+          uses: docker/build-push-action@v4
+          with:
+            file: ./scripts/Dockerfile.migration
+            push: true
+            tags: |
+              ${{ env.DOCKER_USERNAME }}/easyshop-migration:${{ github.sha}}
+            labels: |
+              org.opencontainers.image.source=${{ github.repository }}
+              org.opencontainers.image.revision=${{ github.sha }}
+        
+        - name: Run Trivy vulnerability scan
+          uses: aquasecurity/trivy-action@0.30.0
+          with:
+            image-ref: '${{ env.DOCKER_USERNAME }}/easyshop-app:${{ github.sha }}'
+            format: 'table'
+            exit-code: 0
+            severity: 'CRITICAL,HIGH'
+            output: 'trivy-results.txt'
+      
+        - name: Upload Trivy scan results 
+          uses: actions/upload-artifact@v4
+          with:
+            name: trivy_result_app
+            path: ./trivy-results.txt
+            retention-days: 7
+
+        - name: Configure git for the action
+          run: |
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            
+        - name: Pull latest changes from the remote branch
+          run: git pull origin master --rebase
+
+
+        - name: Update App image tag in manifest file
+          uses: Charlyzzz/update-k8s-image@v1.7.1
+          with:
+            manifest-path: kubernetes/08-easyshop-deployment.yaml
+            new-image-tag: ${{ github.sha }}
+            container-name: easyshop
+
+        - name: Update Migration image tag in manifest file
+          uses: Charlyzzz/update-k8s-image@v1.7.1
+          with:
+            manifest-path: kubernetes/12-migration-job.yaml
+            new-image-tag: ${{ github.sha }}
+            container-name: migration
+
+        - name: Commit deploy manifest on local repo
+          run: |
+            git add kubernetes
+            git commit -s -m "[skip actions]"
+
+        - name: Push manifests to remote repo
+          uses: ad-m/github-push-action@v0.6.0
+          with: 
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            branch: master

--- a/kubernetes/07-mongodb-statefulset.yaml
+++ b/kubernetes/07-mongodb-statefulset.yaml
@@ -29,7 +29,12 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "500m"
-      volumes:
-        - name: mongodb-storage
-          persistentVolumeClaim:
-            claimName: mongodb-pvc
+  volumeClaimTemplates:
+      - metadata:
+          name: mongodb-storage
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          storageClassName: gp2
+          resources:
+            requests:
+              storage: 5Gi    

--- a/kubernetes/08-easyshop-deployment.yaml
+++ b/kubernetes/08-easyshop-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: easyshop
-          image: trainwithshubham/easyshop-app:1
+          image: joakim077/easyshop-app:1
           imagePullPolicy: Always
           ports:
             - containerPort: 3000

--- a/kubernetes/08-easyshop-deployment.yaml
+++ b/kubernetes/08-easyshop-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: easyshop
-          image: joakim077/easyshop-app:c6150f93a17621e1a360b1f33e5b1e58691311bb
+          image: joakim077/easyshop-app:eeb496a9e27830d27c685ad4b15647670e8f8876
           imagePullPolicy: Always
           ports:
             - containerPort: 3000

--- a/kubernetes/08-easyshop-deployment.yaml
+++ b/kubernetes/08-easyshop-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: easyshop
-          image: joakim077/easyshop-app:1
+          image: joakim077/easyshop-app:97b1f22aceee8fbcd58f002aa84134f7d18d3a17
           imagePullPolicy: Always
           ports:
             - containerPort: 3000
@@ -42,11 +42,11 @@ spec:
                   key: JWT_SECRET
           resources:
             requests:
-              memory: "256Mi"
-              cpu: "200m"
+              memory: 256Mi
+              cpu: 200m
             limits:
-              memory: "512Mi"
-              cpu: "500m"
+              memory: 512Mi
+              cpu: 500m
           startupProbe:
             httpGet:
               path: /

--- a/kubernetes/08-easyshop-deployment.yaml
+++ b/kubernetes/08-easyshop-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: easyshop
-          image: joakim077/easyshop-app:97b1f22aceee8fbcd58f002aa84134f7d18d3a17
+          image: joakim077/easyshop-app:c6150f93a17621e1a360b1f33e5b1e58691311bb
           imagePullPolicy: Always
           ports:
             - containerPort: 3000

--- a/kubernetes/12-migration-job.yaml
+++ b/kubernetes/12-migration-job.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: migration
-        image: trainwithshubham/easyshop-migration:1
+        image: joakim077/easyshop-migration:1
         imagePullPolicy: Always
         env:
         - name: MONGODB_URI

--- a/kubernetes/12-migration-job.yaml
+++ b/kubernetes/12-migration-job.yaml
@@ -8,8 +8,7 @@ spec:
     spec:
       containers:
         - name: migration
-          image: >-
-            joakim077/easyshop-migration:c6150f93a17621e1a360b1f33e5b1e58691311bb
+          image: joakim077/easyshop-migration:c6150f93a17621e1a360b1f33e5b1e58691311bb
           imagePullPolicy: Always
           env:
             - name: MONGODB_URI

--- a/kubernetes/12-migration-job.yaml
+++ b/kubernetes/12-migration-job.yaml
@@ -7,10 +7,11 @@ spec:
   template:
     spec:
       containers:
-      - name: migration
-        image: joakim077/easyshop-migration:1
-        imagePullPolicy: Always
-        env:
-        - name: MONGODB_URI
-          value: "mongodb://mongodb-service:27017/easyshop"
+        - name: migration
+          image: >-
+            joakim077/easyshop-migration:97b1f22aceee8fbcd58f002aa84134f7d18d3a17
+          imagePullPolicy: Always
+          env:
+            - name: MONGODB_URI
+              value: mongodb://mongodb-service:27017/easyshop
       restartPolicy: OnFailure

--- a/kubernetes/12-migration-job.yaml
+++ b/kubernetes/12-migration-job.yaml
@@ -8,7 +8,8 @@ spec:
     spec:
       containers:
         - name: migration
-          image: joakim077/easyshop-migration:c6150f93a17621e1a360b1f33e5b1e58691311bb
+          image: >-
+            joakim077/easyshop-migration:eeb496a9e27830d27c685ad4b15647670e8f8876
           imagePullPolicy: Always
           env:
             - name: MONGODB_URI

--- a/kubernetes/12-migration-job.yaml
+++ b/kubernetes/12-migration-job.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
         - name: migration
           image: >-
-            joakim077/easyshop-migration:97b1f22aceee8fbcd58f002aa84134f7d18d3a17
+            joakim077/easyshop-migration:c6150f93a17621e1a360b1f33e5b1e58691311bb
           imagePullPolicy: Always
           env:
             - name: MONGODB_URI


### PR DESCRIPTION
Replaced the static hostPath volume configuration with dynamic EBS volume provisioning using the EBS CSI Driver. This improves data persistence, scalability, and is production-ready compared to local storage. IAM roles and OIDC provider setup are included to support the CSI driver integration with EKS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automated continuous integration with GitHub Actions, including Docker image build, push, vulnerability scanning, and Kubernetes manifest updates.

- **Documentation**
  - Updated setup instructions to include dynamic EBS volume provisioning for MongoDB on AWS EKS.

- **Refactor**
  - Modified MongoDB StatefulSet to use dynamic volume provisioning for storage.
  - Updated resource formatting in deployment manifests for consistency.

- **Chores**
  - Updated application and migration container images in Kubernetes manifests to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->