### PR TITLE
Updated Terraform configs for EKS setup

### DIFF
--- a/terraform/bastion_ec2.tf
+++ b/terraform/bastion_ec2.tf
@@ -1,31 +1,14 @@
-data "aws_ami" "os_image" {
-  owners      = ["099720109477"]
-  most_recent = true
-  filter {
-    name   = "state"
-    values = ["available"]
-  }
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd-gp3/*24.04-amd64*"]
-  }
-}
 
-resource "aws_key_pair" "deployer" {
-  key_name   = "terra-automate-key"
-  public_key = file("terra-key.pub")
-}
 
-resource "aws_security_group" "allow_user_to_connect" {
-  name        = "allow TLS"
+resource "aws_security_group" "allow_user_bastion" {
+  name        = "bastion_host_SG"
   description = "Allow user to connect"
   vpc_id      = module.vpc.vpc_id
   dynamic "ingress" {
     for_each = [
       { description = "port 22 allow", from = 22, to = 22, protocol = "tcp", cidr = ["0.0.0.0/0"] },
       { description = "port 80 allow", from = 80, to = 80, protocol = "tcp", cidr = ["0.0.0.0/0"] },
-      { description = "port 443 allow", from = 443, to = 443, protocol = "tcp", cidr = ["0.0.0.0/0"] },
-      { description = "port 8080 allow", from = 8080, to = 8080, protocol = "tcp", cidr = ["0.0.0.0/0"] }
+      { description = "port 443 allow", from = 443, to = 443, protocol = "tcp", cidr = ["0.0.0.0/0"] }
     ]
     content {
       description = ingress.value.description
@@ -44,30 +27,24 @@ resource "aws_security_group" "allow_user_to_connect" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-
   tags = {
-    Name = "mysecurity"
+    Name = "bastion_security"
   }
 }
 
-resource "aws_instance" "testinstance" {
+resource "aws_instance" "bastion_host" {
   ami                    = data.aws_ami.os_image.id
   instance_type          = var.instance_type
   key_name               = aws_key_pair.deployer.key_name
-  vpc_security_group_ids = [aws_security_group.allow_user_to_connect.id]
+  vpc_security_group_ids = [aws_security_group.allow_user_bastion.id]
   subnet_id              = module.vpc.public_subnets[0]
-  user_data              = file("${path.module}/install_tools.sh")
+  user_data              = file("${path.module}/bastion_user_data.sh")
   tags = {
-    Name = "Jenkins-Automate"
+    Name = "Bastion-Host"
   }
   root_block_device {
     volume_size = 20
     volume_type = "gp3"
   }
 
-}
-
-resource "aws_eip" "jenkins_server_ip" {
-  instance = aws_instance.testinstance.id
-  domain   = "vpc"
 }

--- a/terraform/bastion_user_data.sh
+++ b/terraform/bastion_user_data.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Update packages
+yum update -y
+
+# Install basic tools
+yum install -y git jq curl wget vim unzip tar gzip
+
+# Install AWS CLI v2
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
+unzip /tmp/awscliv2.zip -d /tmp
+/tmp/aws/install
+
+# Install kubectl
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+chmod +x kubectl
+mv kubectl /usr/local/bin/
+
+# Install Helm
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+# Install eksctl
+curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+mv /tmp/eksctl /usr/local/bin/
+
+# Verify installations
+kubectl version --client
+helm version
+eksctl version
+aws --version
+

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -1,67 +1,99 @@
-module "eks" {
+####################
+# eks.tf (minimal)
+####################
 
-  source  = "terraform-aws-modules/eks/aws"
-  version = "19.15.1"
+# Security Group for Node Group SSH access
+resource "aws_security_group" "node_group_remote_access" {
+  name   = "node-group-ssh-access"
+  vpc_id = module.vpc.vpc_id
 
-  cluster_name                   = local.name
-  cluster_endpoint_public_access = true
-
-  cluster_addons = {
-    coredns = {
-      most_recent = true
-    }
-    kube-proxy = {
-      most_recent = true
-    }
-    vpc-cni = {
-      most_recent = true
-    }
+  ingress {
+    description = "Allow SSH (for Bastion access)"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # tighten for production
   }
 
-  vpc_id                   = module.vpc.vpc_id
-  subnet_ids               = module.vpc.public_subnets
-  control_plane_subnet_ids = module.vpc.intra_subnets
-
-  # EKS Managed Node Group(s)
-
-  eks_managed_node_group_defaults = {
-
-    instance_types = ["t2.large"]
-
-    attach_cluster_primary_security_group = true
-
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
-
-  eks_managed_node_groups = {
-
-    tws-demo-ng = {
-      min_size     = 2
-      max_size     = 3
-      desired_size = 2
-
-      instance_types = ["t2.large"]
-      capacity_type  = "SPOT"
-
-      disk_size = 35 
-      use_custom_launch_template = false  # Important to apply disk size!
-
-      tags = {
-        Name = "tws-demo-ng"
-        Environment = "dev"
-        ExtraTag = "e-commerce-app"
-      }
-    }
+  tags = {
+    Name = "${local.name}-node-sg"
   }
- 
-  tags = local.tags
-
-
 }
 
+# Reuse keypair (make sure this exists in another file, e.g. ec2.tf)
+# resource "aws_key_pair" "deployer" { ... }  <-- keep this only once in your configs
+
+# Minimal EKS module config
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  cluster_name    = local.name
+  cluster_version = "1.31"
+
+  # If you want to access API publicly for testing, set public true; else keep private
+  cluster_endpoint_public_access  = true
+  cluster_endpoint_private_access = true
+
+  # VPC & subnets (expects module.vpc to exist)
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  # Minimal addons
+  cluster_addons = {
+    coredns   = { most_recent = true }
+    kube-proxy = { most_recent = true }
+    vpc-cni   = { most_recent = true }
+  }
+
+  # Managed node group(s) - cost-minimised config
+  eks_managed_node_groups = {
+    small-ng = {
+      desired_size = 1
+      min_size     = 1
+      max_size     = 1
+
+      # Use a micro instance to try to stay inside EC2 free-tier (if eligible)
+      instance_types = ["t3.micro"]
+      capacity_type  = "SPOT"   # use "SPOT" only if you are OK with interruptions
+
+      use_custom_launch_template = false
+
+      disk_size = 20
+
+      # remote access via the keypair and SG you already created elsewhere
+      remote_access = {
+        ec2_ssh_key               = aws_key_pair.deployer.key_name
+        source_security_group_ids = [aws_security_group.node_group_remote_access.id]
+      }
+
+      tags = {
+        Name        = "${local.name}-ng"
+        Environment = "dev"
+      }
+
+      # ensure the keypair & SG exist before nodegroup creation
+      depends_on = [
+        aws_key_pair.deployer,
+        aws_security_group.node_group_remote_access
+      ]
+    }
+  }
+
+  tags = merge(local.tags, { "created_by" = "terraform" })
+}
+
+# Optional: small data source to list running node instances (will populate when nodes up)
 data "aws_instances" "eks_nodes" {
   instance_tags = {
-    "eks:cluster-name" = module.eks.cluster_name
+    "eks:cluster-name" = module.eks.cluster_id
   }
 
   filter {

--- a/terraform/install_tool.sh
+++ b/terraform/install_tool.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Update packages
+apt-get update -y
+apt-get upgrade -y
+
+# Install basic tools
+apt-get install -y git jq curl wget vim unzip tar gzip openjdk-11-jdk
+
+# Install AWS CLI v2
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
+unzip /tmp/awscliv2.zip -d /tmp
+/tmp/aws/install
+
+# Install kubectl
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+chmod +x kubectl
+mv kubectl /usr/local/bin/
+
+# Install Helm
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+# Install eksctl
+curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+mv /tmp/eksctl /usr/local/bin/
+
+# Install Jenkins
+wget -O /etc/apt/trusted.gpg.d/jenkins.asc https://pkg.jenkins.io/debian/jenkins.io.key
+sh -c 'echo deb https://pkg.jenkins.io/debian-stable binary/ > /etc/apt/sources.list.d/jenkins.list'
+apt-get update -y
+apt-get install -y jenkins
+systemctl enable jenkins
+systemctl start jenkins
+
+# Install Docker
+curl -fsSL https://get.docker.com -o get-docker.sh
+sh get-docker.sh
+usermod -aG docker ubuntu   # Add default user to docker group
+systemctl enable docker
+systemctl start docker
+
+# Verify installations
+kubectl version --client
+helm version
+eksctl version
+aws --version
+java -version
+jenkins --version
+docker --version
+

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket         = "prachi-eks-terraform-state"
+    key            = "eks/terraform.tfstate"
+    region         = "eu-west-1"
+    dynamodb_table = "terraform-locks"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,16 +1,16 @@
 variable "aws_region" {
   description = "AWS region where resources will be provisioned"
-  default     = "us-east-2"
+  default     = "eu-west-1"
 }
 
 variable "ami_id" {
   description = "AMI ID for the EC2 instance"
-  default     = "ami-085f9c64a9b75eed5"
+  default     = "ami-00233bad963690dd1"
 }
 
 variable "instance_type" {
   description = "Instance type for the EC2 instance"
-  default     = "t2.medium"
+  default     = "t3.micro"
 }
 
 variable "my_enviroment" {

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -10,7 +10,9 @@ module "vpc" {
   private_subnets = local.private_subnets
   intra_subnets   = local.intra_subnets
 
-  enable_nat_gateway = true
+  enable_nat_gateway       = true
+  single_nat_gateway       = true
+  one_nat_gateway_per_az   = false
 
   public_subnet_tags = {
     "kubernetes.io/role/elb" = 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Provisioned a Bastion host with secure access and automated tooling setup (AWS CLI, kubectl, Helm, eksctl).
  - Enhanced EKS deployment with managed node group, core addons, and SSH-enabled remote access.
  - Assigned a static public IP to the example EC2 instance.
- Improvements
  - Streamlined networking with VPC-based security groups/subnets and dynamic ingress rules.
  - Optimized VPC egress via a single NAT gateway.
- Chores
  - Enabled remote Terraform state in S3 with DynamoDB locking.
  - Updated defaults: region to eu-west-1, smaller instance type, and refreshed AMI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->